### PR TITLE
Change ref to handle the check and return a spreadable prop object.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,17 +4,33 @@ Feature detection utilities for [styled-components](https://www.styled-component
 
 ## ref
 
-Boolean value indicating if the version of [styled-components](https://www.styled-components.com/) installed supports `ref` property.
+Helper function which accpets a `refOrInnerRef` handler and returns an object which can be spread in the props of a styled component. The object's key is either `ref` or `innerRef` depending [styled-components](https://www.styled-components.com/) support of the `ref` property. The value is the given ref handler.
 
-```
-import isRefSupported from "@plumbblake/styled-components-feature-detection/ref"
+```jsx
+import React from "react";
+import styled from "styled-components";
+import ref from "@plumbblake/styled-components-feature-detection/ref"
+
+const SomethingStyled = styled.div``;
+
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.myRef = React.createRef();
+  }
+
+  render() {
+    return <SomethingStyled {...ref(this.myRef)} />
+  }
+}
 ```
 
 ## createGlobalStyle
 
 Boolean value indicating if the version of [styled-components](https://www.styled-components.com/) installed supports `createGlobalStyle`.
 
-```
+```js
 import isCreateGlobalStyleSupported from "@plumbblake/styled-components-feature-detection/createGlobalStyle"
 ```
 

--- a/src/features/ref.js
+++ b/src/features/ref.js
@@ -3,6 +3,5 @@ import styled from "styled-components";
 import { isForwardRef } from "react-is";
 
 const StyledComponent = styled.div``;
-const ref = isForwardRef(<StyledComponent />);
 
-export default ref;
+export default (refOrInnerRef) => isForwardRef(<StyledComponent />) ? { ref: refOrInnerRef } : { innerRef: refOrInnerRef };


### PR DESCRIPTION
This change would be a major update to `ref`, but makes it so we don't have to have ternary checks each time we use it.

Current:

    import isRefSupported from "@plumbblake/styled-components-feature-detection/ref";

    <MyStyledComponent  {...(isRefSupported ? { ref: myRef } : { innerRef: myRef })}>

Proposed:

    import ref from "@plumbblake/styled-components-feature-detection/ref";

    <MyStyledComponent  {...ref(myRef)} />
